### PR TITLE
#2 refactor error handling

### DIFF
--- a/src/model/ingest_packet.rs
+++ b/src/model/ingest_packet.rs
@@ -1,16 +1,20 @@
+use actix_web::body::{BodySize, MessageBody};
 use serde::{Serialize, Deserialize};
 use strum_macros::Display;
+use std::io::Write;
 use surrealdb::sql::{Object, Value, Thing};
 use surrealdb::opt::RecordId;
-use std::fmt::Debug;
-use std::fmt;
+use std::{
+    fmt::Debug,
+    fmt};
 
 #[derive(Serialize, Deserialize, Debug)]
 pub struct IngestionPacket {
     pub data : Vec<DataPoint>,
 }
 
-#[derive(Serialize, Deserialize, Debug)]
+
+#[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct DataPoint {
     pub timestamp: i64,
     pub suuid: String,

--- a/src/repository/sdb.rs
+++ b/src/repository/sdb.rs
@@ -57,10 +57,12 @@ impl SDBRepository {
     pub async fn ingest_data(&self, data: IngestionPacket) ->IngestionResponse{
         let mut data_it = data.data.into_iter();
         while let Some(dp) = data_it.next(){
-            let ingest_response: Result<Option<DataPoint>, surrealdb::Error> = self.db.create((dp.suuid.clone(), dp.timestamp.clone())).content(dp).await;
+            let ingest_response: Result<Option<DataPoint>, surrealdb::Error> = self.db.create((dp.suuid.clone(), dp.timestamp.clone())).content(dp.clone()).await;
             match ingest_response{
                 Ok(p) => (),
-                Err(_) => return IngestionResponse::Failed(IngestionPacket{data: data_it.collect()})
+                Err(_) => { let mut failed_data: Vec<DataPoint> = data_it.collect();
+                    failed_data.insert(0, dp);
+                    return IngestionResponse::Failed(IngestionPacket{data: failed_data})}
             }
         }
         IngestionResponse::Success


### PR DESCRIPTION
Changed errorhandling, so that the Response get built directly from the IngestionResponse enum instead of passing it to another Error enum.