### PR TITLE
existing values get skipped on ingestion with multi status rsponse

### DIFF
--- a/src/app/general/mod.rs
+++ b/src/app/general/mod.rs
@@ -1,0 +1,1 @@
+pub mod model;

--- a/src/app/general/model.rs
+++ b/src/app/general/model.rs
@@ -1,0 +1,14 @@
+use actix_web::http;
+use serde::{Serialize, Deserialize};
+
+#[derive(Serialize, Deserialize, Clone)]
+pub struct DefaultErrorResponse {
+    pub status: u16,
+    pub message: String
+}
+
+impl DefaultErrorResponse {
+    pub fn init(code: http::StatusCode, msg: String) -> Self {
+        DefaultErrorResponse { status: code.as_u16(), message: msg}
+    }
+}

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -1,2 +1,3 @@
+pub mod general;
 pub mod signal_meta;
 pub mod signal_data;

--- a/src/app/signal_data/error.rs
+++ b/src/app/signal_data/error.rs
@@ -3,12 +3,11 @@ use actix_web::{
     HttpResponse,
     http::{StatusCode, header::ContentType}};
 use derive_more::Display;
+use super::model::{IngestionPacket, MultiStatusData};
 
-use crate::app::signal_data::model::IngestionPacket;
-
-impl ResponseError for IngestionPacket {
+impl ResponseError for MultiStatusData {
     fn error_response(&self) -> HttpResponse {
-       HttpResponse::build(StatusCode::ACCEPTED) 
+       HttpResponse::build(StatusCode::MULTI_STATUS) 
             .insert_header(ContentType::json())
             .body(serde_json::to_string(&self).unwrap())
     }

--- a/src/app/signal_data/model.rs
+++ b/src/app/signal_data/model.rs
@@ -16,6 +16,31 @@ impl fmt::Display for IngestionPacket{
     }
 }
 
+
+#[derive(Serialize, Deserialize, Debug)]
+pub struct MultiStatusData {
+    pub success : Vec<DataPoint>,
+    pub failed : Vec<DataPoint>,
+    pub already_exists : Vec<DataPoint>
+}
+
+impl fmt::Display for MultiStatusData{
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result{
+        for dp in &self.success{
+            write!(f, "\t{}", dp)?;
+        }
+        for dp in &self.failed{
+            write!(f, "\t{}", dp)?;
+        }
+        for dp in &self.already_exists{
+            write!(f, "\t{}", dp)?;
+        }
+    Ok(())
+    }
+}
+
+
+
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct DataPoint {
     pub timestamp: i64,
@@ -32,7 +57,7 @@ impl fmt::Display for DataPoint{
 
 pub enum IngestionResponse{
     Success,
-    Failed(IngestionPacket)
+    MultiStatus(MultiStatusData)
 }
 
 #[derive(Serialize, Deserialize)]

--- a/src/app/signal_data/route.rs
+++ b/src/app/signal_data/route.rs
@@ -10,7 +10,7 @@ use actix_web::{
 use futures::StreamExt;
 use serde::{Serialize, Deserialize};
 
-use crate::app::signal_data::model::{IngestionPacket, IngestionResponse,
+use crate::app::signal_data::model::{IngestionPacket, IngestionResponse, MultiStatusData,
                                     QueryResponse, QueryResult, QueryTimeseriesData};
 use crate::app::signal_data::error::QueryError;
 use crate::sdb::SDBRepository;
@@ -32,7 +32,7 @@ pub async fn ingest(sdb_repo: Data<SDBRepository>, mut payload: Payload,
     let data_points = serde_json::from_slice::<IngestionPacket>(&body)?;
     match sdb_repo.ingest_data(data_points).await {
         IngestionResponse::Success => Ok(Json("Success".to_string())),
-        IngestionResponse::Failed(response) => Err(response.into())
+        IngestionResponse::MultiStatus(response) => Err(response.into())
     }
 }
 

--- a/src/app/signal_meta/controller.rs
+++ b/src/app/signal_meta/controller.rs
@@ -8,7 +8,7 @@ impl SDBRepository{
             self.db.create(("signal", signal.get_global_id())).content(signal).await;
         match created {
             Ok(_) => Ok(()),
-            Err(_) => Err(SignalError::SignalRegisterFailure),
+            Err(_) => Err(SignalError::SignalRegisterFailure("Signal Already Exists".to_string())),
         }
     }
 

--- a/src/app/signal_meta/route.rs
+++ b/src/app/signal_meta/route.rs
@@ -24,14 +24,14 @@ pub async fn register_signal(sdb_repo: Data<SDBRepository>, mut payload: web::Pa
         let chunk = chunk?;
 
         if (body.len() + chunk.len()) > body_length {
-            return Err(SignalError::Overflow);
+            return Err(SignalError::Overflow("Overflow Error".to_string()));
         }
         body.extend_from_slice(&chunk);
     }
     let signal: Signal = serde_json::from_slice::<Signal>(&body)?;
     match sdb_repo.register_signal(signal).await {
         Ok(()) => Ok(Json("Success".to_string())),
-        Err(_) => Err(SignalError::SignalNotFound)
+        Err(_) => Err(SignalError::SignalAlreadyExists("Signal already exists.".to_string()))
     }
 }
 
@@ -50,6 +50,6 @@ pub async fn get_signal(sdb_repo: Data<SDBRepository>, signal_uuid: Path<SignalI
     let response: Option<Signal> = sdb_repo.get_signal(signal_identifier).await;
     match response {
         Some(response) => Ok(Json(response)),
-        None => Err(SignalError::SignalRegisterFailure)
+        None => Err(SignalError::SignalNotFound)
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -14,7 +14,7 @@ use sdb::SDBRepository;
 #[tokio::main]
 async fn main() -> std::io::Result<()> {
     std::env::set_var("RUST_LOG", "debug");
-    std::env::set_var("RUTS_BACKTRACE", "1");
+    //std::env::set_var("RUST_BACKTRACE", "1");
     env_logger::init();
 
     let sdb_repo: SDBRepository = SDBRepository::init().await;


### PR DESCRIPTION
Ingestion Values, that are already in the DB get skipped. Completely failed ingestion also get added to a buffer. Response then shows a multi status for the data points (success, failed, already_exists).