### PR TITLE
worker doesn't panic anymore, gives Signal with 'not found' fields closes #10

### DIFF
--- a/src/app/signal_data/controller.rs
+++ b/src/app/signal_data/controller.rs
@@ -33,13 +33,14 @@ impl SDBRepository{
 
     pub async fn query_timeseries(&self, data: QueryTimeseriesData) -> QueryResponse{
         let mut response_data:Vec<SignalData> = Vec::new();
+        let mut not_found: Vec<String> = Vec::new();
         let mut query = data.signals.into_iter();
 
         while let Some(signal) = query.next(){
             let signal_query: Result<Option<Signal>, surrealdb::Error> =
                 self.db.select(("signal", &signal)).await;
             let signal_response = match signal_query {
-                Ok(response) => response.unwrap(),
+                Ok(response) => response.unwrap_or(Signal::not_found(&signal)),
                 Err(_) => return QueryResponse::Failed
             };
             let ts_query: Result<Vec<DataPoint>, surrealdb::Error> =

--- a/src/app/signal_data/model.rs
+++ b/src/app/signal_data/model.rs
@@ -93,7 +93,7 @@ pub struct SignalData {
 
 #[derive(Serialize, Deserialize)]
 pub struct QueryResult {
-    pub data: Vec<SignalData>
+    pub data: Vec<SignalData>,
 }
 
 pub enum QueryResponse{

--- a/src/app/signal_meta/model.rs
+++ b/src/app/signal_meta/model.rs
@@ -14,6 +14,18 @@ pub struct Signal {
     pub display_uom: String,
 }
 
+impl Signal {
+    pub fn not_found(search: &String) -> Self {
+        Signal {
+        id: None,
+        uuid: search.clone(),
+        name: "not found".to_string(),
+        uom: "not found".to_string(),
+        display_uom: "not found".to_string()
+        }
+    }
+}
+
 #[derive(Deserialize, Serialize)]
 pub struct SignalIdentifier {
     pub signal_identifier: String


### PR DESCRIPTION
Worker doesn't panic anymore when querying for a signal uuid that doesn't exists. Now will insert an "empty" signal with all fields stating "not found" except the data field which is empty.